### PR TITLE
Agregado Efecto sobre imágenes de Nuestro Equipo

### DIFF
--- a/assets/css/jorgbot_theme.css
+++ b/assets/css/jorgbot_theme.css
@@ -1,0 +1,14 @@
+/*Efecto imagen gris a color*/
+#equipo .item img {
+    filter: grayscale(100%);
+    opacity: 0.8;
+}
+
+#equipo .item:hover img {
+    filter: brightness(150%) saturate(140%);
+    opacity: 1;
+}
+
+#equipo .item:hover {
+    background: linear-gradient(to bottom,rgba(255, 255, 255, 0) 1%,rgb(255, 255, 255));
+}


### PR DESCRIPTION
Ahora las imágenes de los miembros del equipo salen en escala de grises y se ponen en full color al momento de pasar el mouse sobre cada item.